### PR TITLE
Parse project name using YAML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,16 @@
 {
-  "name": "flutter-arq-hex",
-  "version": "0.0.1",
+  "name": "dart-clena-architecture-hex",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "flutter-arq-hex",
-      "version": "0.0.1",
+      "name": "dart-clena-architecture-hex",
+      "version": "1.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      },
       "devDependencies": {
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",
@@ -2284,6 +2288,18 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -3981,6 +3997,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "homepage": "https://github.com/chiuchiolo30/vscode-extension-arq-hex/blob/master/README.md",
   "repository": {
-      "type": "git",
-      "url": "https://github.com/chiuchiolo30/vscode-extension-arq-hex"
+    "type": "git",
+    "url": "https://github.com/chiuchiolo30/vscode-extension-arq-hex"
   },
   "license": "MIT",
   "activationEvents": [
@@ -63,16 +63,19 @@
     "deploy": "vsce publish"
   },
   "devDependencies": {
-    "@types/vscode": "^1.77.0",
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "16.x",
+    "@types/vscode": "^1.77.0",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.56.0",
+    "@vscode/test-electron": "^2.3.0",
     "eslint": "^8.36.0",
     "glob": "^8.1.0",
     "mocha": "^10.2.0",
-    "typescript": "^4.9.5",
-    "@vscode/test-electron": "^2.3.0"
+    "typescript": "^4.9.5"
+  },
+  "dependencies": {
+    "yaml": "^2.8.0"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,21 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { parse } from 'yaml';
+
+const getProjectName = (projectDir: string): string | undefined => {
+    try {
+        const pubspecPath = path.join(projectDir, 'pubspec.yaml');
+        const pubspecContents = fs.readFileSync(pubspecPath, 'utf8');
+        const data = parse(pubspecContents) as { name?: string } | undefined;
+        if (data && typeof data.name === 'string') {
+            return data.name.trim();
+        }
+    } catch (err) {
+        console.error('Failed to parse pubspec.yaml:', err);
+    }
+    return undefined;
+};
 
 
 const transformInput  = (input: string) => input.replace(/([a-z\d])([A-Z])/g, '$1_$2').toLowerCase();
@@ -285,10 +300,11 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 
 			// Obtengo el nombre del proyecto
-			const pubspecPath 		= path.join(currentDir, 'pubspec.yaml');
-			const pubspecContents 	= fs.readFileSync(pubspecPath, 'utf8');
-			const projectName 		= pubspecContents.match(/name: (.+)/)![1] ;
-			const PROJECT_NAME 		= projectName.trim();
+			const PROJECT_NAME = getProjectName(currentDir);
+			if (!PROJECT_NAME) {
+				vscode.window.showInformationMessage("No se pudo determinar el nombre del proyecto desde pubspec.yaml.");
+				return;
+			}
 
 			// Si no existe el directorio [lib] lo creo
 			if(!fs.existsSync(path.join(currentDir, 'lib'))) {
@@ -351,10 +367,11 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 
 			// Obtengo el nombre del proyecto
-			const pubspecPath 		= path.join(currentDir, 'pubspec.yaml');
-			const pubspecContents 	= fs.readFileSync(pubspecPath, 'utf8');
-			const projectName 		= pubspecContents.match(/name: (.+)/)![1] ;
-			const PROJECT_NAME 		= projectName.trim();
+			const PROJECT_NAME = getProjectName(currentDir);
+			if (!PROJECT_NAME) {
+				vscode.window.showInformationMessage("No se pudo determinar el nombre del proyecto desde pubspec.yaml.");
+				return;
+			}
 
 			// Si no existe el directorio [lib] lo creo
 			if(!fs.existsSync(path.join(currentDir, 'lib'))) {
@@ -444,10 +461,11 @@ export function activate(context: vscode.ExtensionContext) {
 				}
 
 				// Obtengo el nombre del proyecto
-				const pubspecPath 		= path.join(currentDir!, 'pubspec.yaml');
-				const pubspecContents 	= fs.readFileSync(pubspecPath, 'utf8');
-				const projectName 		= pubspecContents.match(/name: (.+)/)![1] ;
-				const PROJECT_NAME 		= projectName.trim();
+				const PROJECT_NAME = getProjectName(currentDir!);
+				if (!PROJECT_NAME) {
+					vscode.window.showInformationMessage("No se pudo determinar el nombre del proyecto desde pubspec.yaml.");
+					return;
+				}
 
 				// Valido que exista el repositorio (firma)
 				fs.readFile(path.join(currentDir!,`lib/features/${transformInput(featureName)}/domain/repositories/${transformInput(featureName)}.repository.dart`), 'utf8', (err, data) => {


### PR DESCRIPTION
## Summary
- add yaml dependency
- parse `pubspec.yaml` using yaml package
- handle failures gracefully when no project name

## Testing
- `npm test` *(fails: Exit code SIGSEGV)*

------
https://chatgpt.com/codex/tasks/task_e_68432934ef9c83208e6ba18ea45bd4b5