### PR TITLE
Fix semicolon typo in extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -320,7 +320,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.window.showInputBox({ prompt: 'Ingrese el nombre de la feature por crear' }).then(async featureName => {
 
-		let currentDir = vscode.workspace.rootPath;;
+                let currentDir = vscode.workspace.rootPath;
 
 		if (!currentDir) {
 			if (!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders!.length === 0) {


### PR DESCRIPTION
## Summary
- remove extraneous semicolon after `vscode.workspace.rootPath`

## Testing
- `npm test` *(fails: Exit code SIGSEGV)*

------
https://chatgpt.com/codex/tasks/task_e_68432936765c83208f931035cec8e30a